### PR TITLE
fix: Prevent StdioTransport premature disconnection (Variant 2: stream_select only)

### DIFF
--- a/src/Transport/StdioTransport.php
+++ b/src/Transport/StdioTransport.php
@@ -63,7 +63,25 @@ final class StdioTransport extends EventEmitter implements ServerTransportInterf
         $this->emit('ready');
         $this->emit('client_connected', [self::CLIENT_ID]);
 
-        while (!\feof($this->input)) {
+        while (!$this->closing) {
+            // Wait for data with stream_select to avoid blocking fread() timeout
+            $read = [$this->input];
+            $write = $except = null;
+
+            // Short timeout (1 sec) to check $this->closing flag periodically
+            $result = @\stream_select($read, $write, $except, 1);
+
+            if ($result === false) {
+                $this->logger->error('stream_select() failed');
+                break;
+            }
+
+            if ($result === 0) {
+                // Timeout - no data available, check closing flag and continue
+                continue;
+            }
+
+            // Data is available, safe to read
             // Read in chunks to handle large messages
             // This solves the macOS 8KB fgets() limitation
             $chunk = \fread($this->input, self::READ_CHUNK_SIZE);
@@ -123,7 +141,7 @@ final class StdioTransport extends EventEmitter implements ServerTransportInterf
             \fwrite($this->output, $json . "\n");
             \fflush($this->output); // Ensure message is sent immediately
 
-            $deferred->resolve();
+            $deferred->resolve(null);
         } catch (\JsonException $e) {
             $this->logger->error('JSON encoding failed', [
                 'error' => $e->getMessage(),


### PR DESCRIPTION
Problem:
- MCP server disconnects after ~60 seconds of inactivity
- fread() blocks and returns false when no data available
- This triggers "Failed to read from STDIN" error and breaks the listening loop

Solution (Variant 2):
- Use stream_select() with 1-second timeout to check data availability before reading
- Remove feof() check, rely entirely on stream_select() and $this->closing flag
- Enable graceful shutdown by checking $this->closing flag every second
- Prevents blocking while maintaining responsive shutdown

Testing:
✅ Tested for 150+ seconds without disconnections
✅ Compatible with macOS and other UNIX systems
✅ Graceful shutdown works correctly

Changes:
- Added stream_select() before fread() to wait for available data
- Replaced `while (!\feof($this->input))` with `while (!$this->closing)`
- Short 1-second timeout allows periodic check of $this->closing flag
- Fixed $deferred->resolve() to pass null argument (line 144)

Comparison to Variant 1:
- Simpler code without feof() check
- Relies entirely on stream_select() for EOF detection
- May have edge cases on systems where stream_select() doesn't detect EOF properly