### PR TITLE
 Interceptor pipeline for Action caller

### DIFF
--- a/src/Interceptor/InterceptorPipeline.php
+++ b/src/Interceptor/InterceptorPipeline.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Interceptor;
+
+use Spiral\Core\Attribute\Singleton;
+
+#[Singleton]
+final class InterceptorPipeline
+{
+    /** @var array<ToolInterceptorInterface> */
+    private array $interceptors = [];
+
+    public function addInterceptor(ToolInterceptorInterface $interceptor): void
+    {
+        $this->interceptors[] = $interceptor;
+    }
+
+    /**
+     * @param iterable<ToolInterceptorInterface> $interceptors
+     */
+    public function addInterceptors(iterable $interceptors): void
+    {
+        foreach ($interceptors as $interceptor) {
+            $this->addInterceptor($interceptor);
+        }
+    }
+
+    /**
+     * Execute the interceptor chain.
+     *
+     * @param object $request Request DTO
+     * @param callable(): mixed $action Final action to execute
+     * @return mixed Action result
+     */
+    public function execute(object $request, callable $action): mixed
+    {
+        if (empty($this->interceptors)) {
+            return $action();
+        }
+
+        $pipeline = array_reduce(
+            array_reverse($this->interceptors),
+            fn(callable $next, ToolInterceptorInterface $interceptor): callable =>
+                fn(): mixed => $interceptor->intercept($request, $next),
+            $action,
+        );
+
+        return $pipeline();
+    }
+}

--- a/src/Interceptor/McpServerInterceptorBootloader.php
+++ b/src/Interceptor/McpServerInterceptorBootloader.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Interceptor;
+
+use Spiral\Boot\Bootloader\Bootloader;
+
+final class McpServerInterceptorBootloader extends Bootloader
+{
+    public function defineSingletons(): array
+    {
+        return [
+            InterceptorPipeline::class => InterceptorPipeline::class,
+        ];
+    }
+
+    public function boot(InterceptorPipeline $pipeline): void
+    {
+        // Interceptors can be registered here or via tagged services
+    }
+}

--- a/src/Interceptor/ToolInterceptorInterface.php
+++ b/src/Interceptor/ToolInterceptorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Interceptor;
+
+interface ToolInterceptorInterface
+{
+    /**
+     * Process the request before action execution.
+     *
+     * @param object $request The request DTO (parsed from InputSchema)
+     * @param callable(): mixed $next Next interceptor or action
+     * @return mixed Action result
+     */
+    public function intercept(object $request, callable $next): mixed;
+}

--- a/src/McpServerBootloader.php
+++ b/src/McpServerBootloader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\McpServer;
 
 use Butschster\ContextGenerator\Application\Bootloader\ConsoleBootloader;
+use Butschster\ContextGenerator\McpServer\Interceptor\McpServerInterceptorBootloader;
 use Butschster\ContextGenerator\McpServer\McpConfig\McpConfigBootloader;
 use Butschster\ContextGenerator\McpServer\Projects\McpProjectsBootloader;
 use Butschster\ContextGenerator\McpServer\Prompt\McpPromptBootloader;
@@ -24,6 +25,7 @@ final class McpServerBootloader extends Bootloader
     public function defineDependencies(): array
     {
         return [
+            McpServerInterceptorBootloader::class,
             McpToolBootloader::class,
             McpPromptBootloader::class,
             McpProjectsBootloader::class,


### PR DESCRIPTION
- Add extensible interceptor pipeline to `ActionCaller` for preprocessing tool requests before action execution
- Implement `ToolInterceptorInterface` and `InterceptorPipeline` classes following middleware pattern
- Enable extensible capabilities like project resolution, authentication, validation, logging, and rate limiting

## Usage Example

```php
// Custom interceptor in consumer application
final readonly class LoggingInterceptor implements ToolInterceptorInterface
{
    public function __construct(
        private LoggerInterface $logger,
    ) {}

    public function intercept(object $request, callable $next): mixed
    {
        $this->logger->info('Tool request', ['request' => $request::class]);
        $result = $next();
        $this->logger->info('Tool response', ['success' => true]);
        return $result;
    }
}

// Registration in bootloader
public function boot(InterceptorPipeline $pipeline, LoggingInterceptor $logging): void
{
    $pipeline->addInterceptor($logging);
}
```

See https://github.com/context-hub/generator/issues/293