### PR TITLE
feat: add project removal methods to ProjectService

### DIFF
--- a/src/Projects/ProjectService.php
+++ b/src/Projects/ProjectService.php
@@ -167,6 +167,56 @@ final class ProjectService implements ProjectServiceInterface
         return $this->getState()->resolvePathOrAlias($pathOrAlias);
     }
 
+    public function hasProject(string $pathOrAlias): bool
+    {
+        $state = $this->getState();
+        $resolvedPath = $state->resolvePathOrAlias($pathOrAlias);
+
+        return isset($state->projects[$resolvedPath]);
+    }
+
+    public function removeAlias(string $alias): bool
+    {
+        $state = $this->getState();
+
+        if (!isset($state->aliases[$alias])) {
+            return false;
+        }
+
+        unset($state->aliases[$alias]);
+        $this->saveState($state);
+
+        return true;
+    }
+
+    public function removeProject(string $projectPath): bool
+    {
+        $state = $this->getState();
+
+        if (!isset($state->projects[$projectPath])) {
+            return false;
+        }
+
+        // Remove the project
+        unset($state->projects[$projectPath]);
+
+        // Remove all aliases pointing to this project
+        foreach ($state->aliases as $alias => $path) {
+            if ($path === $projectPath) {
+                unset($state->aliases[$alias]);
+            }
+        }
+
+        // Clear current project if it matches the removed project
+        if ($state->currentProject?->path === $projectPath) {
+            $state->currentProject = null;
+        }
+
+        $this->saveState($state);
+
+        return true;
+    }
+
     /**
      * Get the current project state, loading from storage if necessary
      */

--- a/src/Projects/ProjectServiceInterface.php
+++ b/src/Projects/ProjectServiceInterface.php
@@ -59,4 +59,25 @@ interface ProjectServiceInterface
      * Resolve a path or alias to the actual project path
      */
     public function resolvePathOrAlias(string $pathOrAlias): string;
+
+    /**
+     * Check if a project exists by path or alias
+     */
+    public function hasProject(string $pathOrAlias): bool;
+
+    /**
+     * Remove a specific alias without affecting the project itself
+     *
+     * @return bool True if the alias existed and was removed, false otherwise
+     */
+    public function removeAlias(string $alias): bool;
+
+    /**
+     * Remove a project by its path, including all associated aliases
+     *
+     * If the removed project is the current project, the current project will be cleared.
+     *
+     * @return bool True if the project existed and was removed, false otherwise
+     */
+    public function removeProject(string $projectPath): bool;
 }


### PR DESCRIPTION
Add ability to remove projects and aliases from the registry:

- Add hasProject(string $pathOrAlias): bool - check if project exists
- Add removeAlias(string $alias): bool - remove a specific alias
- Add removeProject(string $projectPath): bool - remove project with alias cleanup

The removeProject method also:
- Removes all aliases pointing to the removed project
- Clears currentProject if it matches the removed project